### PR TITLE
Use Agent.run instead of Agent.initiate_chat

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/workflow.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/workflow.py
@@ -37,11 +37,11 @@ def simple_workflow(ui: UI, params: dict[str, Any]) -> str:
         llm_config=llm_config,
     )
 
-    chat_result = student_agent.initiate_chat(
+    response = student_agent.run(
         teacher_agent,
         message=initial_message,
         summary_method="reflection_with_llm",
         max_turns=3,
     )
 
-    return str(chat_result.summary)
+    return ui.process(response)


### PR DESCRIPTION
Use `Agent.run` instead of `Agent.initiate_chat` to prepare for fastagency's integration of ag2 event streaming

Closes #67 